### PR TITLE
Ignore IDL4 annotations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2018-01-06  Oliver Kellogg  <okellogg@users.sourceforge.net>
+
+	* lexer.l: Skip IDL4 annotations.
+
+==================== 0.8.14 ====================
+
 2009-10-12  Christian Persch  <chpe@gnome.org>
 
 	* Makefile.am:

--- a/lexer.l
+++ b/lexer.l
@@ -169,6 +169,7 @@ escaped_ident		_[A-Za-z0-9_]+
 warn1_ident		[A-Za-z][A-Za-z0-9_]*
 prop_key		[A-Za-z][A-Za-z0-9_]*
 prop_value		\([^\)]+\)
+annotation		@{prop_key}{whitespace}{prop_value}?
 native_type		[^\)]+\)
 sqstring		\'[^\'\n]*[\'\n]
 dqstring		\"[^\"\n]*[\"\n]
@@ -266,6 +267,7 @@ dqstring		\"[^\"\n]*[\"\n]
 	 	tokreturn (TOK_SRCFILE);
 }
 <*>{cpp_other}						;
+<*>{annotation}						;
 <*>{whitespace}						;
 {b8_int}						{
 	yylval.integer = 0;


### PR DESCRIPTION
[IDL4](http://www.omg.org/spec/IDL/4.2/Beta1/PDF) defines a syntax for annotations similar to what is used in Java.
libIDL gets confused by such annotations.
This modification makes the lexer ignore them.